### PR TITLE
Fix browser permission spoof bug

### DIFF
--- a/backend/src/services/pageExtractor.ts
+++ b/backend/src/services/pageExtractor.ts
@@ -99,12 +99,12 @@ export class PageExtractorService {
 
       // Mock permissions - simplified to avoid TypeScript issues
       const originalQuery = window.navigator.permissions.query;
-      window.navigator.permissions.query = (parameters) => {
+      window.navigator.permissions.query = ((parameters: PermissionDescriptor) => {
         if (parameters.name === 'notifications') {
-          return Promise.resolve({ state: 'granted' } as PermissionStatus);
+          return Promise.resolve({ state: 'granted' } as any);
         }
         return originalQuery(parameters);
-      };
+      }) as any;
 
       // Mock plugins
       Object.defineProperty(navigator, 'plugins', {


### PR DESCRIPTION
## Summary
- handle missing PermissionStatus object when spoofing browser permissions
- build backend and frontend to ensure all TypeScript compiles cleanly

## Testing
- `npm run build`
- `npm run build:backend`
- `npm run build:frontend`


------
https://chatgpt.com/codex/tasks/task_e_684ba6467e84832386edc5556393dc08